### PR TITLE
add WIP-06 for did:ckb lexicon

### DIFF
--- a/06.md
+++ b/06.md
@@ -1,0 +1,54 @@
+# WIP-06
+
+## `did:ckb` PDS Extension Lexicon
+
+`draft` `optional` `proposer: Retric Su (Cryptape)`
+
+This document defines the standard for `did:ckb` PDS extension lexicon. The purpose is to add an _optional_ CKB-aware layer to the AT Protocol Personal-Data-Server (PDS) surface by re-using the existing XRPC transport and Lexicon schema language while introducing:
+
+- a CKB-style account-flow (Nervos-CKB address, secp256k1 signature over repo root),
+- pre-flight signing steps so wallets can prompt users once and re-use the signature for the actual write,
+- a small set of index helpers for light-weight queries that do not require repository traversal.
+
+All new schemas are published and MUST be resolved under the NSID authority `fans.web5.ckb.*` and can be imported side-by-side with the official `com.atproto.*` lexicons.
+
+### Design Goals
+
+1. **Wallet-native UX** – the user sees only one signing prompt per logical action.
+2. **Minimal delta** – no forks inside repo data-structures; everything is ordinary AT-Protocol records.
+3. **Incremental adoption** – a PDS that does not understand these NSIDs can safely ignore them; clients that do can speak them with the supported PDS. A future-proof mechanism can be added to allow the PDS advertises the capability via `fans.web5.ckb` in `.well-known/supported-lexicon`, etc.
+
+### Lexicon Overview
+
+| File                    | Purpose                                                           | XRPC Type |
+| ----------------------- | ----------------------------------------------------------------- | --------- |
+| `preCreateAccount.json` | returns the unsigned repo root that must be signed by the CKB key | procedure |
+| `createAccount.json`    | finalises account creation with the signed payload                | procedure |
+| `preDirectWrites.json`  | returns the unsigned commit for a batch write                     | procedure |
+| `directWrites.json`     | applies the batch once the commit is signed                       | procedure |
+| `preIndexAction.json`   | returns the challenge string for login / delete-account           | procedure |
+| `indexAction.json`      | verifies the signed challenge and performs the action             | procedure |
+| `indexQuery.json`       | cheap read-only helpers (counters, DID lookups, …)                | query     |
+| `defs.json`             | shared shapes (`signedRoot`, etc.)                                | —         |
+
+Machine-readable schemas live in [`assets/lexicon/ckb/`](assets/lexicon/ckb). Human-readable examples and sequence diagrams will be added in a future revision.
+
+## CKB-Specific Fields
+
+- `ckbAddr` – Nervos-CKB short-address (bech32m, testnet/mainnet prefix).
+- `signedBytes` – secp256k1 personal-message signature (base64, 65-bytes, recoverable).
+- `signingKey` – did:key string that must resolve to the same secp256k1 pubkey that signed `signedBytes`.
+
+## Security Considerations
+
+- The PDS **must** verify that `ckbAddr` matches the recovered pubkey before persisting any repo root.
+- Challenge messages **must** include the PDS origin to avoid cross-service replay.
+- Clients **should** pin the PDS TLS certificate when obtaining the challenge to prevent MitM downgrade.
+
+## Backwards Compatibility
+
+None of the new procedures collide with existing `com.atproto.*` NSIDs. A legacy PDS returns status 501 for unknown methods; clients fall back to standard flows.
+
+## Reference Implementation
+
+A reference Rust SDK implementation is tracked in [web5-rsky](https://github.com/web5fans/rsky/tree/main/rsky-lexicon). Typescript SDK and PDS plugin might be added later.

--- a/assets/lexicon/ckb/createAccount.json
+++ b/assets/lexicon/ckb/createAccount.json
@@ -1,0 +1,39 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.createAccount",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Finalize account creation with the signed payload returned by preCreateAccount.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["handle", "signingKey", "root", "ckbAddr"],
+          "properties": {
+            "handle": { "type": "string" },
+            "signingKey": { "type": "string" },
+            "password": { "type": "string" },
+            "root": { "type": "ref", "ref": "fans.web5.ckb.defs#signedRoot" },
+            "ckbAddr": { "type": "string" },
+            "inviteCode": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["handle", "did", "accessJwt", "refreshJwt"],
+          "properties": {
+            "handle": { "type": "string" },
+            "did": { "type": "string" },
+            "didDoc": {},
+            "accessJwt": { "type": "string" },
+            "refreshJwt": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/lexicon/ckb/defs.json
+++ b/assets/lexicon/ckb/defs.json
@@ -1,0 +1,18 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.defs",
+  "defs": {
+    "signedRoot": {
+      "type": "object",
+      "required": ["did", "rev", "data", "version", "signedBytes"],
+      "properties": {
+        "did":         { "type": "string" },
+        "rev":         { "type": "string" },
+        "data":        { "type": "string" },
+        "prev":        { "type": "string" },
+        "version":     { "type": "integer", "minimum": 0, "maximum": 255 },
+        "signedBytes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/assets/lexicon/ckb/directWrites.json
+++ b/assets/lexicon/ckb/directWrites.json
@@ -1,0 +1,61 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.directWrites",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Apply a batch of repo writes that have been signed.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["repo", "writes", "signingKey", "root"],
+          "properties": {
+            "repo": { "type": "string" },
+            "validate": { "type": "boolean", "default": true },
+            "writes": {
+              "type": "array",
+              "items": { "type": "union", "refs": ["#create", "#update", "#delete"] }
+            },
+            "swapCommit": { "type": "string" },
+            "signingKey": { "type": "string" },
+            "ckbAddr": { "type": "string" },
+            "root": { "type": "ref", "ref": "fans.web5.ckb.defs#signedRoot" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "commit": { "type": "ref", "ref": "com.atproto.repo.defs#commitMeta" },
+            "results": {
+              "type": "array",
+              "items": { "type": "union", "refs": ["#createResult", "#updateResult", "#deleteResult"] }
+            }
+          }
+        }
+      }
+    },
+    "createResult": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": { "type": "string" },
+        "cid": { "type": "string" },
+        "validationStatus": { "type": "string" }
+      }
+    },
+    "updateResult": {
+      "type": "object",
+      "required": ["uri", "cid"],
+      "properties": {
+        "uri": { "type": "string" },
+        "cid": { "type": "string" },
+        "validationStatus": { "type": "string" }
+      }
+    },
+    "deleteResult": { "type": "object", "properties": {} }
+  }
+}

--- a/assets/lexicon/ckb/indexAction.json
+++ b/assets/lexicon/ckb/indexAction.json
@@ -1,0 +1,51 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.indexAction",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Execute an authentication/session action with a signed message.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "message", "signingKey", "signedBytes", "index"],
+          "properties": {
+            "did": { "type": "string" },
+            "message": { "type": "string" },
+            "signingKey": { "type": "string" },
+            "signedBytes": { "type": "string" },
+            "ckbAddr": { "type": "string" },
+            "index": { "type": "union", "refs": ["#createSession", "#deleteAccount"] }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["result"],
+          "properties": {
+            "result": { "type": "union", "refs": ["#createSessionResult", "#deleteAccountResult"] }
+          }
+        }
+      }
+    },
+    "createSession": { "type": "object", "properties": {} },
+    "deleteAccount": { "type": "object", "properties": {} },
+    "createSessionResult": {
+      "type": "object",
+      "required": ["accessJwt", "refreshJwt", "handle", "did"],
+      "properties": {
+        "accessJwt": { "type": "string" },
+        "refreshJwt": { "type": "string" },
+        "handle": { "type": "string" },
+        "did": { "type": "string" },
+        "didDoc": {},
+        "email": { "type": "string" },
+        "emailConfirmed": { "type": "boolean" }
+      }
+    },
+    "deleteAccountResult": { "type": "object", "properties": {} }
+  }
+}

--- a/assets/lexicon/ckb/indexQuery.json
+++ b/assets/lexicon/ckb/indexQuery.json
@@ -1,0 +1,58 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.indexQuery",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Read-only index queries.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "index": { "type": "union", "refs": ["#firstItem", "#secondItem", "#thirdItem", "#fourthItem"] }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["result"],
+          "properties": {
+            "result": { "type": "union", "refs": ["#firstItemResult", "#secondItemResult", "#thirdItemResult", "#fourthItemResult"] }
+          }
+        }
+      }
+    },
+    "firstItem": { "type": "object", "properties": {} },
+    "secondItem": { "type": "object", "properties": {} },
+    "thirdItem": {
+      "type": "object",
+      "required": ["did"],
+      "properties": { "did": { "type": "string" } }
+    },
+    "fourthItem": {
+      "type": "object",
+      "required": ["did"],
+      "properties": { "did": { "type": "string" } }
+    },
+    "firstItemResult": {
+      "type": "object",
+      "required": ["result"],
+      "properties": { "result": { "type": "integer" } }
+    },
+    "secondItemResult": {
+      "type": "object",
+      "required": ["result"],
+      "properties": { "result": { "type": "integer" } }
+    },
+    "thirdItemResult": {
+      "type": "object",
+      "required": ["result"],
+      "properties": { "result": { "type": "integer" } }
+    },
+    "fourthItemResult": {
+      "type": "object",
+      "required": ["result"],
+      "properties": { "result": { "type": "string" } }
+    }
+  }
+}

--- a/assets/lexicon/ckb/preCreateAccount.json
+++ b/assets/lexicon/ckb/preCreateAccount.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.preCreateAccount",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Pre-flight step for account creation. Returns the unsigned data that must be signed.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["handle", "did"],
+          "properties": {
+            "handle": { "type": "string" },
+            "did": { "type": "string" },
+            "signingKey": { "type": "string" },
+            "inviteCode": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "rev", "data", "version", "unSignBytes"],
+          "properties": {
+            "did": { "type": "string" },
+            "rev": { "type": "string" },
+            "data": { "type": "string" },
+            "prev": { "type": "string" },
+            "version": { "type": "integer", "minimum": 0, "maximum": 255 },
+            "unSignBytes": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/lexicon/ckb/preDirectWrites.json
+++ b/assets/lexicon/ckb/preDirectWrites.json
@@ -1,0 +1,67 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.preDirectWrites",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Pre-flight step for a batch repo write. Returns the unsigned data that must be signed.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["repo", "writes"],
+          "properties": {
+            "repo": { "type": "string" },
+            "validate": { "type": "boolean", "default": true },
+            "writes": {
+              "type": "array",
+              "items": { "type": "union", "refs": ["#create", "#update", "#delete"] }
+            },
+            "swapCommit": { "type": "string" }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "rev", "data", "version", "unSignBytes"],
+          "properties": {
+            "did": { "type": "string" },
+            "rev": { "type": "string" },
+            "data": { "type": "string" },
+            "prev": { "type": "string" },
+            "version": { "type": "integer", "minimum": 0, "maximum": 255 },
+            "unSignBytes": { "type": "string" }
+          }
+        }
+      }
+    },
+    "create": {
+      "type": "object",
+      "required": ["collection", "value"],
+      "properties": {
+        "collection": { "type": "string" },
+        "rkey": { "type": "string" },
+        "value": {}
+      }
+    },
+    "update": {
+      "type": "object",
+      "required": ["collection", "rkey", "value"],
+      "properties": {
+        "collection": { "type": "string" },
+        "rkey": { "type": "string" },
+        "value": {}
+      }
+    },
+    "delete": {
+      "type": "object",
+      "required": ["collection", "rkey"],
+      "properties": {
+        "collection": { "type": "string" },
+        "rkey": { "type": "string" }
+      }
+    }
+  }
+}

--- a/assets/lexicon/ckb/preIndexAction.json
+++ b/assets/lexicon/ckb/preIndexAction.json
@@ -1,0 +1,36 @@
+{
+  "lexicon": 1,
+  "id": "fans.web5.ckb.preIndexAction",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Pre-flight step for authentication/session actions.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "index"],
+          "properties": {
+            "did": { "type": "string" },
+            "ckbAddr": { "type": "string" },
+            "index": { "type": "union", "refs": ["#createSession", "#deleteAccount"] }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["did", "handle", "message"],
+          "properties": {
+            "did": { "type": "string" },
+            "handle": { "type": "string" },
+            "message": { "type": "string" }
+          }
+        }
+      }
+    },
+    "createSession": { "type": "object", "properties": {} },
+    "deleteAccount": { "type": "object", "properties": {} }
+  }
+}


### PR DESCRIPTION
This PR publishes the first draft of WIP-06, an optional CKB-aware extension to the AT-Protocol PDS surface. All schemas are pure Lexicon 1 JSON and live under the NSID authority `fans.web5.ckb.*`

[preview](https://github.com/web5fans/web5-wips/blob/wip-06/06.md)

TODO:

Register the authoritative DID for `fans.web5.ckb` lexicon resolution.

- Create / choose a DID (`did:ckb:xxxx`) that will own the namespace.  
  - This did `did:ckb:xxxx` should be controled under multisig or any other suitable locks.
- Add DNS TXT record:  
  `_lexicon.ckb.web5.fans` → `did=<chosen-did>`
- Publish each lexicon JSON as a record in collection `com.atproto.lexicon.schema` with rkey = full NSID (`fans.web5.ckb.*`) under that DID’s repo.  
- Verify resolution:  check against the returned schema when given any `fans.web5.ckb.*` NSID.